### PR TITLE
Added foreign_key check bypass for tests.

### DIFF
--- a/templates/default/settings.py.erb
+++ b/templates/default/settings.py.erb
@@ -1,4 +1,5 @@
 import os
+import sys
 
 # Django settings for pgd project.
 
@@ -17,6 +18,8 @@ DATABASES = {
         'PORT' : '<%= @database_port %>',
     }
 }
+if 'test' in sys.argv:
+    DATABASES['default']['OPTIONS'] = {'init_command': 'SET foreign_key_checks=0'}
 
 ##### End Database Configuration #####
 


### PR DESCRIPTION
Sometimes MySQL and Django fail to cooperate when populating fixtures.
This fix temporarily bypasses foreign key checks when setting up
databases during tests.
